### PR TITLE
Add Physical Condition Field to Bed Management Forms

### DIFF
--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-form.component.tsx
@@ -27,11 +27,21 @@ import type { BedType, BedWithLocation } from '../types';
  * Adds translation for occupancy status options
  * t('occupancyStatusAvailable', 'Available')
  * t('occupancyStatusOccupied', 'Occupied')
+ *
+ * Adds translation for physical condition options
+ * t('physicalConditionNew', 'New')
+ * t('physicalConditionGood', 'Good')
+ * t('physicalConditionFair', 'Fair')
+ * t('physicalConditionBroken', 'Broken')
+ * t('physicalConditionDamaged', 'Damaged')
+ * t('physicalConditionDecommissioned', 'Decommissioned')
  */
 
 interface BedAdministrationFormProps {
   allLocations: Location[];
   availableBedTypes: Array<BedType>;
+  /** List of physical condition options */
+  physicalConditions: string[];
   handleCreateBed?: (formData: BedAdministrationData) => void;
   headerTitle: string;
   initialData: BedWithLocation;
@@ -74,12 +84,16 @@ const createSchema = (t: TFunction) => {
     bedType: z.string().refine((value) => value != '', {
       message: t('invalidBedType', 'Please select a valid bed type'),
     }),
+    physicalCondition: z.string().refine((value) => value != '', {
+      message: t('invalidPhysicalCondition', 'Please select a valid physical condition'),
+    }),
   });
 };
 
 const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
   allLocations,
   availableBedTypes,
+  physicalConditions,
   handleCreateBed,
   headerTitle,
   initialData,
@@ -109,6 +123,7 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
       bedType: initialData.bedType?.name ?? '',
       location: initialData.location ?? {},
       occupancyStatus: capitalize(initialData.status) ?? occupancyStatus,
+      physicalCondition: initialData.physicalCondition ?? '',
     },
   });
 
@@ -249,6 +264,32 @@ const BedAdministrationForm: React.FC<BedAdministrationFormProps> = ({
                       <SelectItem text={bedType.name} value={bedType.name} key={`bedType-${index}`}>
                         {bedType.name}
                       </SelectItem>
+                    ))}
+                  </Select>
+                )}
+              />
+            </FormGroup>
+            <FormGroup>
+              <Controller
+                name="physicalCondition"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <Select
+                    defaultValue={initialData.physicalCondition ?? ''}
+                    id="physicalCondition"
+                    invalidText={fieldState.error?.message}
+                    labelText={t('physicalCondition', 'Physical condition')}
+                    {...field}>
+                    <SelectItem
+                      text={t('choosePhysicalCondition', 'Choose a physical condition')}
+                      value=""
+                    />
+                    {physicalConditions.map((condition, index) => (
+                      <SelectItem
+                        key={`physicalCondition-${index}`}
+                        text={t(`physicalCondition${condition}`, `${condition}`)}
+                        value={condition}
+                      />
                     ))}
                   </Select>
                 )}

--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-table.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-table.component.tsx
@@ -111,6 +111,10 @@ const BedAdministrationTable: React.FC = () => {
       header: t('allocationStatus', 'Allocated'),
     },
     {
+      key: 'physicalCondition',
+      header: t('physicalCondition', 'Physical condition'),
+    },
+    {
       key: 'actions',
       header: t('actions', 'Actions'),
     },
@@ -123,6 +127,7 @@ const BedAdministrationTable: React.FC = () => {
       location: bed.location.display,
       occupancyStatus: <CustomTag condition={bed?.status === 'OCCUPIED'} />,
       allocationStatus: <CustomTag condition={Boolean(bed.location?.uuid)} />,
+      physicalCondition: t(`physicalCondition${bed.physicalCondition}`, `${bed.physicalCondition}`),
       actions: (
         <>
           <Button

--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration-types.ts
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration-types.ts
@@ -8,6 +8,8 @@ export interface BedAdministrationData {
     uuid: string;
   };
   occupancyStatus: string;
+  /** Selected physical condition of the bed */
+  physicalCondition: string;
 }
 
 export interface BedTypeDataAdministration {

--- a/packages/esm-bed-management-app/src/bed-administration/bed-administration.resource.ts
+++ b/packages/esm-bed-management-app/src/bed-administration/bed-administration.resource.ts
@@ -10,6 +10,8 @@ interface BedForm {
   column: number;
   status: string;
   locationUuid: string;
+  /** Physical condition of the bed */
+  physicalCondition: string;
 }
 
 export async function saveBed({ bedPayload }: { bedPayload: BedPostPayload }): Promise<FetchResponse<BedForm>> {

--- a/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/edit-bed-form.component.tsx
@@ -20,6 +20,7 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ closeModal, editData, mutate 
   const availableBedTypes = bedTypes ? bedTypes : [];
   const headerTitle = t('editBed', 'Edit bed');
   const occupancyStatuses = ['Available', 'Occupied'];
+  const physicalConditions = ['New', 'Good', 'Fair', 'Broken', 'Damaged', 'Decommissioned'];
 
   const handleCreateBed = useCallback(
     (formData: BedAdministrationData) => {
@@ -32,6 +33,7 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ closeModal, editData, mutate 
         bedType = editData.bedType.name,
         location: { uuid: bedLocation = editData.location.uuid },
         occupancyStatus = editData.status,
+        physicalCondition = editData.physicalCondition,
       } = formData;
 
       const bedPayload = {
@@ -41,6 +43,7 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ closeModal, editData, mutate 
         locationUuid: bedLocation,
         row: parseInt(bedRow),
         status: occupancyStatus.toUpperCase(),
+        physicalCondition,
       };
 
       editBed({ bedPayload, bedId: bedUuid })
@@ -82,6 +85,7 @@ const EditBedForm: React.FC<EditBedFormProps> = ({ closeModal, editData, mutate 
     <BedAdministrationForm
       allLocations={admissionLocations}
       availableBedTypes={availableBedTypes}
+      physicalConditions={physicalConditions}
       handleCreateBed={handleCreateBed}
       headerTitle={headerTitle}
       initialData={editData}

--- a/packages/esm-bed-management-app/src/bed-administration/new-bed-form.component.tsx
+++ b/packages/esm-bed-management-app/src/bed-administration/new-bed-form.component.tsx
@@ -21,6 +21,7 @@ const NewBedForm: React.FC<NewBedFormProps> = ({ closeModal, mutate, defaultLoca
   const headerTitle = t('createNewBed', 'Create a new bed');
   const occupancyStatuses = ['Available', 'Occupied'];
   const availableBedTypes = bedTypes ? bedTypes : [];
+  const physicalConditions = ['New', 'Good', 'Fair', 'Broken', 'Damaged', 'Decommissioned'];
 
   const initialData: BedWithLocation = {
     bedNumber: '',
@@ -35,7 +36,7 @@ const NewBedForm: React.FC<NewBedFormProps> = ({ closeModal, mutate, defaultLoca
 
   const handleCreateBed = useCallback(
     (formData: BedAdministrationData) => {
-      const { bedId, occupancyStatus, bedRow, bedColumn, location, bedType } = formData;
+      const { bedId, occupancyStatus, bedRow, bedColumn, location, bedType, physicalCondition } = formData;
 
       const bedObject = {
         bedNumber: bedId,
@@ -44,6 +45,7 @@ const NewBedForm: React.FC<NewBedFormProps> = ({ closeModal, mutate, defaultLoca
         row: parseInt(bedRow.toString()),
         column: parseInt(bedColumn.toString()),
         locationUuid: location.uuid,
+        physicalCondition,
       };
 
       saveBed({ bedPayload: bedObject })
@@ -69,15 +71,16 @@ const NewBedForm: React.FC<NewBedFormProps> = ({ closeModal, mutate, defaultLoca
   );
 
   return (
-    <BedAdministrationForm
-      closeModal={closeModal}
-      allLocations={admissionLocations}
-      availableBedTypes={availableBedTypes}
-      handleCreateBed={handleCreateBed}
-      headerTitle={headerTitle}
-      occupancyStatuses={occupancyStatuses}
-      initialData={initialData}
-    />
+      <BedAdministrationForm
+        closeModal={closeModal}
+        allLocations={admissionLocations}
+        availableBedTypes={availableBedTypes}
+        physicalConditions={physicalConditions}
+        handleCreateBed={handleCreateBed}
+        headerTitle={headerTitle}
+        occupancyStatuses={occupancyStatuses}
+        initialData={initialData}
+      />
   );
 };
 

--- a/packages/esm-bed-management-app/src/types.ts
+++ b/packages/esm-bed-management-app/src/types.ts
@@ -86,6 +86,8 @@ export interface Bed {
   row: number;
   column: number;
   status: 'AVAILABLE' | 'OCCUPIED';
+  /** Physical condition of the bed (e.g., New, Good, Fair, Broken, Damaged, Decommissioned) */
+  physicalCondition?: string;
 }
 
 export interface BedWithLocation extends Bed {
@@ -123,6 +125,8 @@ export interface BedPostPayload {
   column: number;
   status: string;
   locationUuid: string;
+  /** Physical condition of the bed */
+  physicalCondition: string;
 }
 
 export interface BedTagPayload {


### PR DESCRIPTION
### Description
This PR introduces a new feature to the `esm-bed-management-app` by adding a 'Physical Condition' field to the bed management forms. This update allows hospital administrators to track and manage the physical condition of beds, which is crucial for maintenance and optimal utilization.

### Changes Made
- Updated `edit-bed-form.component.tsx` and `new-bed-form.component.tsx` to include a new field for `physicalCondition`.
- Modified `bed-administration-form.component.tsx` to handle the new `physicalCondition` field with validation.
- Updated `bed-administration-table.component.tsx` to display the physical condition of each bed.
- Enhanced type definitions in `bed-administration-types.ts` and `types.ts` to include `physicalCondition`.
- Added translations for physical condition options.

### Business Context
The healthcare facility requires tracking the physical condition of beds to ensure proper maintenance and utilization. This includes conditions like new, good, fair, broken, damaged, and decommissioned.

### User Story
As a hospital administrator, I want to track the physical condition of each bed so that I can manage maintenance and optimize bed usage.

### Acceptance Criteria
1. The system should allow setting and updating the physical condition of a bed.
2. The physical condition should be visible in the UI.

### Test Cases
1. Verify that the physical condition can be set and updated in the UI.
2. Verify that the physical condition is displayed correctly in the UI.

### Technical Details
- Added a new field for `physicalCondition` in the `edit-bed-form.component.tsx` and `new-bed-form.component.tsx`.
- Updated the `BedAdministrationForm` to include a dropdown for selecting the physical condition.
- Ensured that the physical condition is correctly passed and displayed in the bed administration table.

### Out of Scope
Backend API changes are not included in this update.